### PR TITLE
Add timing instrumentation and verbose argument

### DIFF
--- a/R/coloc_result.R
+++ b/R/coloc_result.R
@@ -14,6 +14,8 @@
 #'   `"too_few_snps"`, `"no_harmonised_variants"`. Default `"success"`.
 #' @param status_reason Character or `NULL`. Human-readable explanation when
 #'   `status != "success"`.
+#' @param timing Named numeric vector of elapsed times (seconds) for each
+#'   major step inside `run_coloc()`. Empty by default.
 #'
 #' @return An object of class `coloc_result`.
 #'
@@ -28,7 +30,8 @@ new_coloc_result <- function(
   methods_skipped = character(),
   params = list(),
   status = "success",
-  status_reason = NULL
+  status_reason = NULL,
+  timing = numeric(0)
 ) {
   structure(
     list(
@@ -41,7 +44,8 @@ new_coloc_result <- function(
       methods_skipped = methods_skipped,
       params = params,
       status = status,
-      status_reason = status_reason
+      status_reason = status_reason,
+      timing = timing
     ),
     class = "coloc_result"
   )

--- a/R/mr_result.R
+++ b/R/mr_result.R
@@ -14,6 +14,8 @@
 #'   `"no_harmonised_variants"`. Default `"success"`.
 #' @param status_reason Character or `NULL`. Human-readable explanation when
 #'   `status != "success"`.
+#' @param timing Named numeric vector of elapsed times (seconds) for each
+#'   major step inside `run_mr()`. Empty by default.
 #'
 #' @return An object of class `mr_result`.
 #'
@@ -27,7 +29,8 @@ new_mr_result <- function(
   ld_matrix = NULL,
   params = list(),
   status = "success",
-  status_reason = NULL
+  status_reason = NULL,
+  timing = numeric(0)
 ) {
   structure(
     list(
@@ -39,7 +42,8 @@ new_mr_result <- function(
       ld_matrix = ld_matrix,
       params = params,
       status = status,
-      status_reason = status_reason
+      status_reason = status_reason,
+      timing = timing
     ),
     class = "mr_result"
   )

--- a/R/run_coloc.R
+++ b/R/run_coloc.R
@@ -54,9 +54,13 @@
 #'   Default `1e-4`.
 #' @param p12 Numeric. Prior probability a SNP is associated with both
 #'   traits. Default `1e-5`.
+#' @param verbose Logical. If `TRUE`, emit informational messages via
+#'   [cli::cli_inform()]. Warnings and errors are always emitted regardless.
+#'   Default `TRUE`.
 #'
 #' @return A `coloc_result` object. Check `result$status` for `"success"` vs
-#'   failure reasons.
+#'   failure reasons. The `$timing` field contains a named numeric vector of
+#'   elapsed seconds for each major step.
 #'
 #' @seealso [new_coloc_result()] for the S3 class structure,
 #'   [print.coloc_result()] and [summary.coloc_result()] for display methods.
@@ -98,7 +102,8 @@ run_coloc <- function(
   p1 = 1e-4,
 
   p2 = 1e-4,
-  p12 = 1e-5
+  p12 = 1e-5,
+  verbose = TRUE
 ) {
   # --- Validate arguments ---------------------------------------------------
 
@@ -145,7 +150,11 @@ run_coloc <- function(
     p12 = p12
   )
 
+  timing <- numeric(0)
+
   # --- Filter exposure to window --------------------------------------------
+
+  t0 <- proc.time()[["elapsed"]]
 
   chr_val <- as.character(gene_chr) |>
     stringr::str_remove("^chr")
@@ -163,6 +172,7 @@ run_coloc <- function(
     cli::cli_warn(
       "No exposure SNPs in region chr{chr_val}:{min_pos}-{max_pos}."
     )
+    timing[["filter_window"]] <- proc.time()[["elapsed"]] - t0
     return(new_coloc_result(
       status = "no_snps_in_region",
       status_reason = paste0(
@@ -173,7 +183,8 @@ run_coloc <- function(
         "-",
         max_pos
       ),
-      params = params
+      params = params,
+      timing = timing
     ))
   }
 
@@ -188,6 +199,7 @@ run_coloc <- function(
 
   if (nrow(outcome_in_window) == 0) {
     cli::cli_warn("No outcome SNPs in region chr{chr_val}:{min_pos}-{max_pos}.")
+    timing[["filter_window"]] <- proc.time()[["elapsed"]] - t0
     return(new_coloc_result(
       status = "no_snps_in_region",
       status_reason = paste0(
@@ -198,7 +210,8 @@ run_coloc <- function(
         "-",
         max_pos
       ),
-      params = params
+      params = params,
+      timing = timing
     ))
   }
 
@@ -219,9 +232,15 @@ run_coloc <- function(
     log_pval = FALSE
   )
 
+  timing[["filter_window"]] <- proc.time()[["elapsed"]] - t0
+
   # --- Harmonise ------------------------------------------------------------
 
+  t0 <- proc.time()[["elapsed"]]
+
   harmonised <- harmonise_and_filter(exposure_filt, outcome_data)
+
+  timing[["harmonisation"]] <- proc.time()[["elapsed"]] - t0
 
   if (nrow(harmonised) < 3) {
     status <- if (nrow(harmonised) == 0) {
@@ -245,7 +264,8 @@ run_coloc <- function(
       harmonised_data = harmonised,
       status = status,
       status_reason = reason,
-      params = params
+      params = params,
+      timing = timing
     ))
   }
 
@@ -275,6 +295,8 @@ run_coloc <- function(
 
   # --- LD matrix ------------------------------------------------------------
 
+  t0 <- proc.time()[["elapsed"]]
+
   ld_mat <- compute_ld_matrix(
     snps = harmonised$SNP,
     bfile = bfile,
@@ -283,6 +305,8 @@ run_coloc <- function(
   aligned <- align_to_ld_matrix(harmonised, ld_mat)
   harmonised <- aligned$data
   ld_mat <- aligned$ld_matrix
+
+  timing[["ld_matrix"]] <- proc.time()[["elapsed"]] - t0
 
   if (nrow(harmonised) < 3) {
     cli::cli_warn(
@@ -297,7 +321,8 @@ run_coloc <- function(
         nrow(harmonised),
         " SNP(s) after LD alignment (need >= 3)"
       ),
-      params = params
+      params = params,
+      timing = timing
     ))
   }
 
@@ -348,6 +373,7 @@ run_coloc <- function(
 
   # ABF
   if ("abf" %in% methods) {
+    t0 <- proc.time()[["elapsed"]]
     coloc_abf_res <- tryCatch(
       coloc::coloc.abf(
         dataset1 = dataset_exp,
@@ -362,12 +388,14 @@ run_coloc <- function(
         NULL
       }
     )
+    timing[["coloc_abf"]] <- proc.time()[["elapsed"]] - t0
   }
 
   # SuSiE
   susie_exp <- NULL
   susie_out <- NULL
   if ("susie" %in% methods) {
+    t0 <- proc.time()[["elapsed"]]
     susie_result <- tryCatch(
       {
         s_exp <- coloc::runsusie(dataset_exp)
@@ -387,10 +415,12 @@ run_coloc <- function(
       susie_out <- susie_result$susie_out
       coloc_susie_res <- susie_result$coloc_susie
     }
+    timing[["coloc_susie"]] <- proc.time()[["elapsed"]] - t0
   }
 
   # Signals (requires SuSiE)
   if ("signals" %in% methods) {
+    t0 <- proc.time()[["elapsed"]]
     if (!"susie" %in% methods) {
       cli::cli_warn(
         "{.val signals} requires {.val susie}; skipping because {.val susie} was not requested."
@@ -417,6 +447,7 @@ run_coloc <- function(
         }
       )
     }
+    timing[["coloc_signals"]] <- proc.time()[["elapsed"]] - t0
   }
 
   # Prop test (requires signals + colocPropTest)
@@ -472,6 +503,7 @@ run_coloc <- function(
     n_snps = n_snps,
     harmonised_data = harmonised,
     methods_skipped = methods_skipped,
-    params = params
+    params = params,
+    timing = timing
   )
 }

--- a/R/run_mr.R
+++ b/R/run_mr.R
@@ -61,9 +61,13 @@
 #'   `samplesize.exposure` column.
 #' @param presso_n_dist Integer. Number of distributions for MR-PRESSO. Default
 #'   `1000`.
+#' @param verbose Logical. If `TRUE`, emit informational messages via
+#'   [cli::cli_inform()]. Warnings and errors are always emitted regardless.
+#'   Default `TRUE`.
 #'
 #' @return An `mr_result` object. Check `result$status` for `"success"` vs
-#'   failure reasons.
+#'   failure reasons. The `$timing` field contains a named numeric vector of
+#'   elapsed seconds for each major step.
 #'
 #' @export
 run_mr <- function(
@@ -84,7 +88,8 @@ run_mr <- function(
   methods = c("ivw", "egger", "weighted_median", "presso", "conmix", "steiger"),
   ld_correct = FALSE,
   exposure_n = NULL,
-  presso_n_dist = 1000
+  presso_n_dist = 1000,
+  verbose = TRUE
 ) {
   # --- Validate arguments ---------------------------------------------------
 
@@ -127,11 +132,17 @@ run_mr <- function(
     presso_n_dist = presso_n_dist
   )
 
+  timing <- numeric(0)
+
   # --- Instrument selection -------------------------------------------------
+
+  t0 <- proc.time()[["elapsed"]]
 
   if (!is.null(instruments)) {
     # Manual mode
-    cli::cli_inform("Using {length(instruments)} manual instrument{?s}.")
+    if (verbose) {
+      cli::cli_inform("Using {length(instruments)} manual instrument{?s}.")
+    }
     exposure_iv <- exposure[exposure$SNP %in% instruments, ]
 
     missing <- setdiff(instruments, exposure_iv$SNP)
@@ -146,17 +157,21 @@ run_mr <- function(
 
     if (nrow(exposure_iv) == 0) {
       cli::cli_warn("No manual instruments found in exposure data.")
+      timing[["instrument_selection"]] <- proc.time()[["elapsed"]] - t0
       return(new_mr_result(
         status = "no_instruments",
         status_reason = "No manual instruments found in exposure data",
-        params = params
+        params = params,
+        timing = timing
       ))
     }
   } else if (!is.null(instrument_region)) {
     # Cis-MR mode
-    cli::cli_inform(
-      "Cis-MR mode: chr{instrument_region$chromosome}:{instrument_region$start}-{instrument_region$end} (+/- {window}bp)."
-    )
+    if (verbose) {
+      cli::cli_inform(
+        "Cis-MR mode: chr{instrument_region$chromosome}:{instrument_region$start}-{instrument_region$end} (+/- {window}bp)."
+      )
+    }
 
     exposure_iv <- exposure |>
       dplyr::filter(
@@ -171,6 +186,7 @@ run_mr <- function(
       cli::cli_warn(
         "No significant instruments in cis region for {.val {exposure_id}}."
       )
+      timing[["instrument_selection"]] <- proc.time()[["elapsed"]] - t0
       return(new_mr_result(
         status = "no_instruments",
         status_reason = paste0(
@@ -178,7 +194,8 @@ run_mr <- function(
           exposure_id,
           "'"
         ),
-        params = params
+        params = params,
+        timing = timing
       ))
     }
 
@@ -204,6 +221,7 @@ run_mr <- function(
       cli::cli_warn(
         "No instruments remaining after clumping for {.val {exposure_id}}."
       )
+      timing[["instrument_selection"]] <- proc.time()[["elapsed"]] - t0
       return(new_mr_result(
         status = "no_instruments",
         status_reason = paste0(
@@ -211,14 +229,17 @@ run_mr <- function(
           exposure_id,
           "'"
         ),
-        params = params
+        params = params,
+        timing = timing
       ))
     }
   } else {
     # Genome-wide mode
-    cli::cli_inform(
-      "Genome-wide mode: selecting instruments at p < {pval_thresh}."
-    )
+    if (verbose) {
+      cli::cli_inform(
+        "Genome-wide mode: selecting instruments at p < {pval_thresh}."
+      )
+    }
 
     exposure_iv <- exposure |>
       dplyr::filter(.data$pval.exposure < pval_thresh)
@@ -227,6 +248,7 @@ run_mr <- function(
       cli::cli_warn(
         "No genome-wide significant instruments for {.val {exposure_id}}."
       )
+      timing[["instrument_selection"]] <- proc.time()[["elapsed"]] - t0
       return(new_mr_result(
         status = "no_instruments",
         status_reason = paste0(
@@ -234,7 +256,8 @@ run_mr <- function(
           exposure_id,
           "'"
         ),
-        params = params
+        params = params,
+        timing = timing
       ))
     }
 
@@ -260,6 +283,7 @@ run_mr <- function(
       cli::cli_warn(
         "No instruments remaining after clumping for {.val {exposure_id}}."
       )
+      timing[["instrument_selection"]] <- proc.time()[["elapsed"]] - t0
       return(new_mr_result(
         status = "no_instruments",
         status_reason = paste0(
@@ -267,12 +291,17 @@ run_mr <- function(
           exposure_id,
           "'"
         ),
-        params = params
+        params = params,
+        timing = timing
       ))
     }
   }
 
+  timing[["instrument_selection"]] <- proc.time()[["elapsed"]] - t0
+
   # --- Region exclusion -----------------------------------------------------
+
+  t0 <- proc.time()[["elapsed"]]
 
   if (!is.null(exclude_regions) && "chr.exposure" %in% colnames(exposure_iv)) {
     in_excluded <- rep(FALSE, nrow(exposure_iv))
@@ -287,14 +316,17 @@ run_mr <- function(
     if (any(in_excluded)) {
       n_removed <- sum(in_excluded)
       exposure_iv <- exposure_iv[!in_excluded, ]
-      cli::cli_inform(
-        "Removed {n_removed} instrument{?s} in excluded region{?s}."
-      )
+      if (verbose) {
+        cli::cli_inform(
+          "Removed {n_removed} instrument{?s} in excluded region{?s}."
+        )
+      }
 
       if (nrow(exposure_iv) == 0) {
         cli::cli_warn(
           "All instruments for {.val {exposure_id}} fall in excluded regions."
         )
+        timing[["region_exclusion"]] <- proc.time()[["elapsed"]] - t0
         return(new_mr_result(
           status = "no_instruments",
           status_reason = paste0(
@@ -302,13 +334,18 @@ run_mr <- function(
             exposure_id,
             "' fall in excluded regions"
           ),
-          params = params
+          params = params,
+          timing = timing
         ))
       }
     }
   }
 
+  timing[["region_exclusion"]] <- proc.time()[["elapsed"]] - t0
+
   # --- Format outcome and harmonise -----------------------------------------
+
+  t0 <- proc.time()[["elapsed"]]
 
   outcome_data <- TwoSampleMR::format_data(
     outcome,
@@ -330,6 +367,8 @@ run_mr <- function(
 
   harmonised <- harmonise_and_filter(exposure_iv, outcome_data)
 
+  timing[["harmonisation"]] <- proc.time()[["elapsed"]] - t0
+
   if (nrow(harmonised) == 0) {
     cli::cli_warn(
       "No variants remaining after harmonisation for {.val {exposure_id}}."
@@ -341,7 +380,8 @@ run_mr <- function(
         exposure_id,
         "'"
       ),
-      params = params
+      params = params,
+      timing = timing
     ))
   }
 
@@ -355,6 +395,8 @@ run_mr <- function(
 
   # --- LD correction --------------------------------------------------------
 
+  t0 <- proc.time()[["elapsed"]]
+
   ld_mat <- NULL
   if (ld_correct) {
     ld_mat <- compute_ld_matrix(
@@ -366,6 +408,8 @@ run_mr <- function(
     harmonised <- aligned$data
     ld_mat <- aligned$ld_matrix
   }
+
+  timing[["ld_correction"]] <- proc.time()[["elapsed"]] - t0
 
   # --- F-statistics ---------------------------------------------------------
 
@@ -385,6 +429,7 @@ run_mr <- function(
   # Wald ratio for single instrument
 
   if (n_snps == 1) {
+    t0 <- proc.time()[["elapsed"]]
     wald <- TwoSampleMR::mr(harmonised, method_list = "mr_wald_ratio")
     results_list[["Wald ratio"]] <- data.frame(
       exposure = exposure_id,
@@ -396,6 +441,7 @@ run_mr <- function(
       pval = wald$pval,
       stringsAsFactors = FALSE
     )
+    timing[["mr_ivw"]] <- proc.time()[["elapsed"]] - t0
 
     # Skip all multi-SNP methods
     multi_methods <- intersect(
@@ -408,6 +454,7 @@ run_mr <- function(
   } else {
     # IVW
     if ("ivw" %in% methods) {
+      t0 <- proc.time()[["elapsed"]]
       if (ld_correct) {
         mr_input <- MendelianRandomization::mr_input(
           bx = harmonised$beta.exposure,
@@ -440,10 +487,12 @@ run_mr <- function(
           stringsAsFactors = FALSE
         )
       }
+      timing[["mr_ivw"]] <- proc.time()[["elapsed"]] - t0
     }
 
     # Egger (requires >= 3 SNPs)
     if ("egger" %in% methods) {
+      t0 <- proc.time()[["elapsed"]]
       if (n_snps < 3) {
         methods_skipped["egger"] <- "Requires >= 3 instruments"
       } else if (ld_correct) {
@@ -481,10 +530,12 @@ run_mr <- function(
           stringsAsFactors = FALSE
         )
       }
+      timing[["mr_egger"]] <- proc.time()[["elapsed"]] - t0
     }
 
     # Weighted median (requires >= 3 SNPs)
     if ("weighted_median" %in% methods) {
+      t0 <- proc.time()[["elapsed"]]
       if (n_snps < 3) {
         methods_skipped["weighted_median"] <- "Requires >= 3 instruments"
       } else {
@@ -500,10 +551,12 @@ run_mr <- function(
           stringsAsFactors = FALSE
         )
       }
+      timing[["mr_weighted_median"]] <- proc.time()[["elapsed"]] - t0
     }
 
     # MR-PRESSO (requires >= 3 SNPs)
     if ("presso" %in% methods) {
+      t0 <- proc.time()[["elapsed"]]
       if (n_snps < 3) {
         methods_skipped["presso"] <- "Requires >= 3 instruments"
       } else {
@@ -538,10 +591,12 @@ run_mr <- function(
           }
         }
       }
+      timing[["mr_presso"]] <- proc.time()[["elapsed"]] - t0
     }
 
     # ConMix
     if ("conmix" %in% methods) {
+      t0 <- proc.time()[["elapsed"]]
       conmix_result <- tryCatch(
         {
           mr_input <- MendelianRandomization::mr_input(
@@ -570,12 +625,14 @@ run_mr <- function(
           stringsAsFactors = FALSE
         )
       }
+      timing[["mr_conmix"]] <- proc.time()[["elapsed"]] - t0
     }
   }
 
   # Steiger (works with any number of SNPs if sample sizes available)
   steiger_result <- NULL
   if ("steiger" %in% methods) {
+    t0 <- proc.time()[["elapsed"]]
     if (is.null(exp_n)) {
       methods_skipped["steiger"] <- "Exposure sample size not available"
     } else {
@@ -590,6 +647,7 @@ run_mr <- function(
         }
       )
     }
+    timing[["mr_steiger"]] <- proc.time()[["elapsed"]] - t0
   }
 
   # --- Assemble results -----------------------------------------------------
@@ -617,7 +675,8 @@ run_mr <- function(
     steiger = steiger_result,
     methods_skipped = methods_skipped,
     ld_matrix = ld_mat,
-    params = params
+    params = params,
+    timing = timing
   )
 }
 

--- a/man/new_coloc_result.Rd
+++ b/man/new_coloc_result.Rd
@@ -14,7 +14,8 @@ new_coloc_result(
   methods_skipped = character(),
   params = list(),
   status = "success",
-  status_reason = NULL
+  status_reason = NULL,
+  timing = numeric(0)
 )
 }
 \arguments{
@@ -41,6 +42,9 @@ values are reasons for skipping.}
 
 \item{status_reason}{Character or \code{NULL}. Human-readable explanation when
 \code{status != "success"}.}
+
+\item{timing}{Named numeric vector of elapsed times (seconds) for each
+major step inside \code{run_coloc()}. Empty by default.}
 }
 \value{
 An object of class \code{coloc_result}.

--- a/man/new_mr_result.Rd
+++ b/man/new_mr_result.Rd
@@ -13,7 +13,8 @@ new_mr_result(
   ld_matrix = NULL,
   params = list(),
   status = "success",
-  status_reason = NULL
+  status_reason = NULL,
+  timing = numeric(0)
 )
 }
 \arguments{
@@ -39,6 +40,9 @@ values are reasons for skipping.}
 
 \item{status_reason}{Character or \code{NULL}. Human-readable explanation when
 \code{status != "success"}.}
+
+\item{timing}{Named numeric vector of elapsed times (seconds) for each
+major step inside \code{run_mr()}. Empty by default.}
 }
 \value{
 An object of class \code{mr_result}.

--- a/man/run_coloc.Rd
+++ b/man/run_coloc.Rd
@@ -24,7 +24,8 @@ run_coloc(
   methods = c("abf", "susie", "signals"),
   p1 = 1e-04,
   p2 = 1e-04,
-  p12 = 1e-05
+  p12 = 1e-05,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -85,10 +86,15 @@ Default \code{1e-4}.}
 
 \item{p12}{Numeric. Prior probability a SNP is associated with both
 traits. Default \code{1e-5}.}
+
+\item{verbose}{Logical. If \code{TRUE}, emit informational messages via
+\code{\link[cli:cli_abort]{cli::cli_inform()}}. Warnings and errors are always emitted regardless.
+Default \code{TRUE}.}
 }
 \value{
 A \code{coloc_result} object. Check \code{result$status} for \code{"success"} vs
-failure reasons.
+failure reasons. The \verb{$timing} field contains a named numeric vector of
+elapsed seconds for each major step.
 }
 \description{
 Runs colocalization between a pre-formatted exposure and a raw outcome

--- a/man/run_mr.Rd
+++ b/man/run_mr.Rd
@@ -22,7 +22,8 @@ run_mr(
   methods = c("ivw", "egger", "weighted_median", "presso", "conmix", "steiger"),
   ld_correct = FALSE,
   exposure_n = NULL,
-  presso_n_dist = 1000
+  presso_n_dist = 1000,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -78,10 +79,15 @@ exclude the MHC region: \code{data.frame(chr = "6", start = 26e6, end = 34e6)}.}
 
 \item{presso_n_dist}{Integer. Number of distributions for MR-PRESSO. Default
 \code{1000}.}
+
+\item{verbose}{Logical. If \code{TRUE}, emit informational messages via
+\code{\link[cli:cli_abort]{cli::cli_inform()}}. Warnings and errors are always emitted regardless.
+Default \code{TRUE}.}
 }
 \value{
 An \code{mr_result} object. Check \code{result$status} for \code{"success"} vs
-failure reasons.
+failure reasons. The \verb{$timing} field contains a named numeric vector of
+elapsed seconds for each major step.
 }
 \description{
 Runs MR with automatic instrument selection (cis-MR, genome-wide, or manual)


### PR DESCRIPTION
## Summary
- Add `$timing` field to `mr_result` and `coloc_result` S3 objects
- Instrument `run_mr()` and `run_coloc()` with `proc.time()` timing around each major step
- Add `verbose = TRUE` parameter to both functions; gate `cli::cli_inform()` behind it

## Test plan
- [x] `devtools::test()` — 127 tests pass, 0 failures
- [x] `devtools::check()` — 0 errors, pre-existing warnings only
- [x] `air format .` — clean

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)